### PR TITLE
修复无法赋值

### DIFF
--- a/CloudKeyboard.Core/TypingText.cs
+++ b/CloudKeyboard.Core/TypingText.cs
@@ -52,7 +52,7 @@ namespace Walterlv.CloudTyping
             }
         }
 
-        public bool Enter { get; private set; }
+        public bool Enter { get; set; }
 
         public void Freeze()
         {


### PR DESCRIPTION
如果这个属性是私有的，那么调用的时候将会不断收到 false 值